### PR TITLE
fix(upload): send real File objects from frontend and accept UploadFile params

### DIFF
--- a/frontend.html
+++ b/frontend.html
@@ -228,7 +228,9 @@
         const compareDropArea = document.getElementById('compare-drop-area');
         const compareInput = document.getElementById('compare-input');
         const compareBtn = document.getElementById('compare-btn');
-        
+
+        let selectedPayslipFile = null;
+        let selectedCompareFiles = [];
         let currentFileContent = null;
         let currentAnalysis = null;
         
@@ -277,66 +279,55 @@
             fileInput.click();
         });
         
-        async function handleFiles(files) {
-            if (files.length > 0) {
-                const file = files[0];
-                
-                // Show loading message
-                addBotMessage("מעלה ומנתח את הקובץ...", true);
-                
-                // Show file preview
-                filePreview.classList.remove('hidden');
-                uploadedFiles.innerHTML = '';
-                
-                const fileElement = document.createElement('div');
-                fileElement.className = 'flex items-center space-x-3 space-x-reverse bg-slate-700 p-3 rounded-lg';
-                fileElement.innerHTML = `
-                    <i data-lucide="file-text" class="w-5 h-5 text-blue-400"></i>
-                    <div class="flex-1 min-w-0">
-                        <p class="text-sm truncate">${file.name}</p>
-                        <p class="text-xs text-slate-400">${(file.size / 1024).toFixed(1)} KB</p>
-                    </div>
-                    <i data-lucide="check-circle" class="w-5 h-5 text-green-500"></i>
-                `;
-                uploadedFiles.appendChild(fileElement);
-                lucide.createIcons();
-                
-                try {
-                    // Create FormData and upload file
-                    const formData = new FormData();
-                    formData.append('file', file);
-                    
-                    console.log('Uploading file to:', `${API_BASE}/analyze-payslip`);
-                    const response = await fetch(`${API_BASE}/analyze-payslip`, {
-                        method: 'POST',
-                        body: formData
-                    });
-                    
-                    console.log('Upload response status:', response.status);
-                    
-                    if (response.ok) {
-                        const result = await response.json();
-                        currentFileContent = result.extracted_text;
-                        currentAnalysis = result.analysis;
-                        
-                        // Remove loading message and add results
-                        removeLastBotMessage();
-                        addBotMessage(result.analysis);
-                        
-                        // Update history
-                        loadHistory();
-                    } else {
-                        removeLastBotMessage();
-                        const errorText = await response.text();
-                        console.error('Upload error:', errorText);
-                        addBotMessage("שגיאה בעיבוד הקובץ. אנא נסה שוב.");
-                    }
-                } catch (error) {
-                    console.error('Network error:', error);
-                    removeLastBotMessage();
-                    addBotMessage("שגיאה בתקשורת עם השרת. נסה שוב בעוד רגע.");
-                }
+        function handleFiles(files) {
+            const f = files && files[0] ? files[0] : null;
+            selectedPayslipFile = f;
+            console.log('[single] picked:', f ? {name: f.name, size: f.size, type: f.type} : null);
+            if (!f) return;
+
+            // Show file preview
+            filePreview.classList.remove('hidden');
+            uploadedFiles.innerHTML = '';
+
+            const fileElement = document.createElement('div');
+            fileElement.className = 'flex items-center space-x-3 space-x-reverse bg-slate-700 p-3 rounded-lg';
+            fileElement.innerHTML = `
+                <i data-lucide="file-text" class="w-5 h-5 text-blue-400"></i>
+                <div class="flex-1 min-w-0">
+                    <p class="text-sm truncate">${f.name}</p>
+                    <p class="text-xs text-slate-400">${(f.size / 1024).toFixed(1)} KB</p>
+                </div>
+                <i data-lucide="check-circle" class="w-5 h-5 text-green-500"></i>
+            `;
+            uploadedFiles.appendChild(fileElement);
+            lucide.createIcons();
+
+            analyzeSingle();
+        }
+
+        async function analyzeSingle() {
+            if (!selectedPayslipFile) {
+                addBotMessage("לא נבחר קובץ.");
+                return;
             }
+            addBotMessage("מעלה ומנתח את הקובץ...", true);
+            const fd = new FormData();
+            fd.append('file', selectedPayslipFile);
+
+            const res = await fetch(`${API_BASE}/analyze-payslip`, { method: 'POST', body: fd });
+            const data = await res.json();
+            if (!res.ok) {
+                console.error('analyze error:', data);
+                removeLastBotMessage();
+                addBotMessage(data.detail || "שגיאה בעיבוד הקובץ.");
+                return;
+            }
+
+            currentFileContent = data.extracted_text;
+            currentAnalysis = data.analysis;
+            removeLastBotMessage();
+            addBotMessage(data.analysis);
+            loadHistory();
         }
         
         // Chat functionality
@@ -524,73 +515,53 @@
             const files = dt.files;
             handleComparisonFiles(files);
         }, false);
-        
+
         compareInput.addEventListener('change', function() {
             handleComparisonFiles(this.files);
         });
-        
-        async function handleComparisonFiles(files) {
-            if (files.length < 2) {
-                addBotMessage("נדרשים לפחות 2 קבצים להשוואה. אנא בחר עוד קבצים.");
+
+        function handleComparisonFiles(files) {
+            const arr = Array.from(files || []);
+            selectedCompareFiles = arr;
+            console.log('[compare] picked:', arr.map(f => ({name: f.name, size: f.size, type: f.type})));
+            comparePayslips();
+        }
+
+        async function comparePayslips() {
+            if (!selectedCompareFiles || selectedCompareFiles.length < 2) {
+                addBotMessage("נדרשים לפחות 2 קבצים להשוואה.");
                 return;
             }
-            
-            if (files.length > 5) {
+            if (selectedCompareFiles.length > 5) {
                 addBotMessage("ניתן להשוות עד 5 תלושים בו-זמנית. אנא בחר פחות קבצים.");
                 return;
             }
-            
-            // Show loading message
-            addBotMessage(`מעלה ומשווה ${files.length} תלושים...`, true);
-            
-            try {
-                // Create FormData and upload files
-                const formData = new FormData();
-                for (let i = 0; i < files.length; i++) {
-                    formData.append('files', files[i]);
-                }
-                
-                console.log('Comparing files at:', `${API_BASE}/compare-payslips`);
-                const response = await fetch(`${API_BASE}/compare-payslips`, {
-                    method: 'POST',
-                    body: formData
-                });
-                
-                console.log('Comparison response status:', response.status);
-                
-                if (response.ok) {
-                    const result = await response.json();
-                    
-                    // Remove loading message and add results
-                    removeLastBotMessage();
-                    
-                    // Show comparison results
-                    let comparisonMessage = `השוואה בין ${result.total_files} תלושים:<br><br>`;
-                    comparisonMessage += `<strong>קבצים שהושוו:</strong><br>`;
-                    result.payslips.forEach((payslip, index) => {
-                        comparisonMessage += `${index + 1}. ${payslip.filename}<br>`;
-                    });
-                    comparisonMessage += `<br><strong>ניתוח השוואה:</strong><br>${result.comparison_analysis}`;
-                    
-                    addBotMessage(comparisonMessage);
-                    
-                    // Update current context for questions
-                    currentFileContent = result.payslips.map(p => `${p.filename}: ${p.extracted_text}`).join('\n\n');
-                    currentAnalysis = result.comparison_analysis;
-                    
-                    // Update history
-                    loadHistory();
-                } else {
-                    removeLastBotMessage();
-                    const errorText = await response.text();
-                    console.error('Comparison error:', errorText);
-                    addBotMessage("שגיאה בהשוואת התלושים. אנא נסה שוב.");
-                }
-            } catch (error) {
-                console.error('Network error during comparison:', error);
+
+            addBotMessage(`מעלה ומשווה ${selectedCompareFiles.length} תלושים...`, true);
+            const fd = new FormData();
+            selectedCompareFiles.forEach(f => fd.append('files', f));
+
+            const res = await fetch(`${API_BASE}/compare-payslips`, { method: 'POST', body: fd });
+            const data = await res.json();
+            if (!res.ok) {
+                console.error('compare error:', data);
                 removeLastBotMessage();
-                addBotMessage("שגיאה בתקשורת עם השרת במהלך ההשוואה.");
+                addBotMessage(data.detail || "שגיאה בהשוואת התלושים.");
+                return;
             }
+
+            removeLastBotMessage();
+            let comparisonMessage = `השוואה בין ${data.total_files} תלושים:<br><br>`;
+            comparisonMessage += `<strong>קבצים שהושוו:</strong><br>`;
+            data.payslips.forEach((payslip, index) => {
+                comparisonMessage += `${index + 1}. ${payslip.filename}<br>`;
+            });
+            comparisonMessage += `<br><strong>ניתוח השוואה:</strong><br>${data.comparison_analysis}`;
+            addBotMessage(comparisonMessage);
+
+            currentFileContent = data.payslips.map(p => `${p.filename}: ${p.extracted_text}`).join('\n\n');
+            currentAnalysis = data.comparison_analysis;
+            loadHistory();
         }
         
         // Load history on page load


### PR DESCRIPTION
## Summary
- use UploadFile parameters for analyzing payslips and simplified debug endpoint
- track selected File objects in the frontend and post them via FormData
- streamline multi-file comparison flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0503394c8330946e4b5739bc6e7c