### PR TITLE
feat(memory): save payslip text and answer questions from history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ Thumbs.db
 # Database
 *.db-journal
 payslip_data.db
+payslips.db
 *.sqlite
 *.db
 

--- a/db.py
+++ b/db.py
@@ -1,0 +1,49 @@
+import sqlite3, os, json, time, uuid
+# Simple SQLite storage for payslip text
+DB_PATH = os.getenv("DB_PATH", "payslips.db")
+
+def _conn():
+    con = sqlite3.connect(DB_PATH)
+    con.execute("PRAGMA journal_mode=WAL;")
+    return con
+
+def init_db():
+    con = _conn()
+    con.execute("""
+    CREATE TABLE IF NOT EXISTS payslips (
+      id TEXT PRIMARY KEY,
+      text TEXT NOT NULL,
+      meta TEXT,
+      created_at REAL
+    )
+    """)
+    con.commit(); con.close()
+
+def save_payslip(text: str, meta: dict) -> str:
+    pid = str(uuid.uuid4())
+    con = _conn()
+    con.execute("INSERT INTO payslips (id, text, meta, created_at) VALUES (?, ?, ?, ?)",
+                (pid, text, json.dumps(meta or {}), time.time()))
+    con.commit(); con.close()
+    return pid
+
+def get_payslip(pid: str) -> str | None:
+    con = _conn()
+    cur = con.execute("SELECT text FROM payslips WHERE id = ?", (pid,))
+    row = cur.fetchone()
+    con.close()
+    return row[0] if row else None
+
+def latest_payslip_id() -> str | None:
+    con = _conn()
+    cur = con.execute("SELECT id FROM payslips ORDER BY created_at DESC LIMIT 1")
+    row = cur.fetchone()
+    con.close()
+    return row[0] if row else None
+
+def list_payslips(limit:int=20):
+    con = _conn()
+    cur = con.execute("SELECT id, created_at FROM payslips ORDER BY created_at DESC LIMIT ?", (limit,))
+    rows = [{"id": r[0], "created_at": r[1]} for r in cur.fetchall()]
+    con.close()
+    return rows

--- a/frontend.html
+++ b/frontend.html
@@ -317,18 +317,16 @@
             let data;
             try { data = await res.json(); } catch (e) { data = { detail: 'Invalid JSON response' }; }
 
+            stopTyping();
             if (!res.ok) {
                 console.error('analyze error:', data);
                 addBotMessage(data.detail || "שגיאה בעיבוד הקובץ.");
-                stopTyping();
                 return;
             }
 
-            stopTyping();
-            currentFileContent = data.extracted_text;
-            currentAnalysis = data.analysis;
-            addBotMessage("✔️ הקובץ עובד! " + JSON.stringify(data));
-            loadHistory();
+            localStorage.setItem('activePayslipId', data.payslip_id);
+            addBotMessage("✅ " + (data.message || "התלוש נשמר. אפשר לשאול שאלות."));
+            return;
         }
         
         // Chat functionality
@@ -342,36 +340,21 @@
                 addBotMessage("חושב...", true);
                 
                 // Send message to API
-                sendQuestionToAPI(message);
+                sendQuestion(message);
             }
         }
-        
-        async function sendQuestionToAPI(question) {
-            try {
-                const response = await fetch(`${API_BASE}/ask-question`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                        question: question,
-                        context: currentFileContent || '',
-                        previous_analysis: currentAnalysis || ''
-                    })
-                });
-                
-                if (response.ok) {
-                    const result = await response.json();
-                    removeLastBotMessage();
-                    addBotMessage(result.answer);
-                } else {
-                    removeLastBotMessage();
-                    addBotMessage("שגיאה בקבלת תשובה. אנא נסה שוב.");
-                }
-            } catch (error) {
-                removeLastBotMessage();
-                addBotMessage("שגיאה בתקשורת עם השרת.");
-            }
+
+        async function sendQuestion(text) {
+            const pid = localStorage.getItem('activePayslipId');
+            const res = await fetch(`${API_BASE}/ask`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ question: text, payslip_id: pid })
+            });
+            const data = await res.json().catch(() => ({ detail: 'Invalid JSON' }));
+            removeLastBotMessage();
+            if (!res.ok) { addBotMessage(data.detail || "שגיאה בשאלה."); return; }
+            addBotMessage(data.answer);
         }
         
         function addUserMessage(message) {

--- a/tests/test_backend_pdf.py
+++ b/tests/test_backend_pdf.py
@@ -13,15 +13,42 @@ def create_pdf_bytes(text: str) -> bytes:
         return doc.tobytes()
 
 
-def test_analyze_payslip_pdf_endpoint(monkeypatch):
+def test_analyze_and_ask(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
     backend = importlib.import_module("backend")
-    monkeypatch.setattr(backend, "explain_payslip_with_knowledge", lambda text, client: "analysis")
     client = TestClient(backend.app)
+
+    captured = {}
+
+    class DummyClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(model, messages, stream=False, timeout=60):
+                    captured["messages"] = messages
+                    class Res:
+                        choices = [type("Choice", (), {"message": type("Msg", (), {"content": "answer"})()})]
+                    return Res()
+
+    import openai
+    monkeypatch.setattr(openai, "OpenAI", lambda *a, **k: DummyClient())
+
     pdf_bytes = create_pdf_bytes("Gross 10000")
-    response = client.post("/analyze-payslip", files={"file": ("test.pdf", pdf_bytes, "application/pdf")})
+    response = client.post(
+        "/analyze-payslip",
+        files={"file": ("test.pdf", pdf_bytes, "application/pdf")},
+    )
     assert response.status_code == 200
     data = response.json()
-    assert "Gross 10000" in data["extracted_text"]
-    assert data["analysis"] == "analysis"
+    assert data["ok"] is True
+    assert "payslip_id" in data
+
+    ask_resp = client.post(
+        "/ask",
+        json={"question": "?", "payslip_id": data["payslip_id"]},
+    )
+    assert ask_resp.status_code == 200
+    ask_data = ask_resp.json()
+    assert ask_data["answer"] == "answer"
+    assert "Gross 10000" in captured["messages"][1]["content"]


### PR DESCRIPTION
## Summary
- persist extracted payslip text in a lightweight SQLite store
- return only a short confirmation with `payslip_id` on upload
- add `/ask` endpoint and wire frontend to send questions with `payslip_id`

## Testing
- `pytest tests/test_backend_pdf.py::test_analyze_and_ask -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab55855c10833093774d6bd42b96e8