### PR TITLE
Speed up PDF OCR for large PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ open http://127.0.0.1:8000/
 - Env var: add `OPENAI_API_KEY` (sync: off, paste your key)
 - OCR support: include `apt.txt` with `tesseract-ocr`
 
+### Performance budgets
+
+The backend limits how much OCR work is done per request to keep slow PDFs from
+blocking the service. You can tweak these via environment variables:
+
+- `MAX_PAGES` – maximum pages to scan from a PDF (default `50`)
+- `MAX_OCR_PAGES` – maximum pages to OCR when no text is found (default `3`)
+- `MAX_TOTAL_SECONDS` – overall time budget for extraction (default `60` seconds)
+
 ## Testing
 
 Run the unit tests with:

--- a/tests/test_pdf_limits.py
+++ b/tests/test_pdf_limits.py
@@ -1,0 +1,21 @@
+import importlib
+import fitz
+
+
+def create_multi_page_pdf(texts):
+    doc = fitz.open()
+    for txt in texts:
+        page = doc.new_page()
+        page.insert_text((72, 72), txt)
+    return doc.tobytes()
+
+
+def test_respects_max_pages(monkeypatch):
+    monkeypatch.setenv("MAX_PAGES", "2")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    backend = importlib.reload(importlib.import_module("backend"))
+    pdf_bytes = create_multi_page_pdf(["one", "two", "three"])
+    text, ocr_used, _ = backend.extract_text_from_pdf(pdf_bytes)
+    assert "one" in text and "two" in text
+    assert "three" not in text
+    assert ocr_used == 0


### PR DESCRIPTION
## Summary
- Limit PDF scanning via `MAX_PAGES` environment variable
- Parallelize OCR for scanned pages to reduce processing time
- Document OCR performance budgets and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab587c2cb48330af5473dacdad2f0e