### PR TITLE
Improve OCR extraction for scanned PDFs

### DIFF
--- a/tests/test_ocr_rotation.py
+++ b/tests/test_ocr_rotation.py
@@ -1,0 +1,34 @@
+import io
+import importlib
+import os
+
+from PIL import Image, ImageDraw
+import pytest
+
+
+def create_scanned_pdf(text: str, rotate: int = 0) -> bytes:
+    """Create a one-page PDF from rendered text, optionally rotated."""
+    img = Image.new("RGB", (600, 200), "white")
+    draw = ImageDraw.Draw(img)
+    draw.text((10, 80), text, fill="black")
+    if rotate:
+        img = img.rotate(rotate, expand=True)
+    buf = io.BytesIO()
+    img.save(buf, format="PDF")
+    return buf.getvalue()
+
+
+def test_rotated_pdf_ocr(monkeypatch):
+    """Ensure OCR can handle sideways scanned PDFs."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    backend = importlib.reload(importlib.import_module("backend"))
+
+    if not backend.TESSERACT_AVAILABLE:
+        pytest.skip("tesseract not available")
+
+    pdf_bytes = create_scanned_pdf("Gross 12345", rotate=90)
+    text, pages_used, _ = backend.extract_text_from_pdf(pdf_bytes)
+
+    assert "Gross 12345" in text
+    assert pages_used >= 1
+


### PR DESCRIPTION
## Summary
- improve OCR by trying multiple rotations for scanned pages and images
- bump default OCR scale for better small-text recognition
- add regression test verifying OCR handles rotated PDFs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0327e81848330908ecb3c794e28cc