### PR TITLE
Enable Hebrew OCR support

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -1,2 +1,3 @@
 tesseract-ocr
-tesseract-ocr-all
+tesseract-ocr-eng
+tesseract-ocr-heb

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ openai>=1.97.0
 pillow>=11.3.0
 pydantic>=2.11.7
 pymupdf>=1.26.3
+pytesseract>=0.3.13
 python-multipart>=0.0.20
 streamlit>=1.47.0
 uvicorn[standard]>=0.35.0

--- a/src/ingest/extractor.py
+++ b/src/ingest/extractor.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 OCR_DPI = int(os.getenv("OCR_DPI", "150"))  # resolution used for OCR fallback
 MAX_TOTAL_SECONDS = float(os.getenv("MAX_TOTAL_SECONDS", "30"))
-OCR_LANG = os.getenv("OCR_LANG", "eng")
+OCR_LANG = os.getenv("OCR_LANG", "heb+eng")
 
 
 def _extract_pdf(pdf_bytes: bytes) -> str:


### PR DESCRIPTION
## Summary
- Install Tesseract Hebrew and English packages via apt.txt
- Include pytesseract Python wrapper and default OCR to Hebrew+English

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03810f21c8330ade17cf0f458aa1e