### PR TITLE
Add Tesseract fallback OCR backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 
 export OPENAI_API_KEY=your_key_here  # if needed by your handlers
-export GOOGLE_API_KEY=your_google_api_key  # required for Gemini OCR
+# Optional: set to use Google Gemini for OCR; otherwise Tesseract is used
+export GOOGLE_API_KEY=your_google_api_key
 uvicorn backend:app --reload --port 8000
 ```
 
@@ -28,7 +29,8 @@ open http://127.0.0.1:8000/
 - `startCommand`: `uvicorn backend:app --host 0.0.0.0 --port $PORT`
 - `healthCheckPath`: `/healthz`
 - Env var: add `OPENAI_API_KEY` (sync: off, paste your key)
-- OCR support: requires a Google Gemini API key in `GOOGLE_API_KEY`
+- OCR support: optionally add `GOOGLE_API_KEY` for Gemini OCR; otherwise ensure
+  the `tesseract` binary is installed on the host
 
 ## Testing
 
@@ -39,5 +41,7 @@ pytest
 ```
 
 ### OCR on Render
-This app uses Google's Gemini API for scanned PDFs/images.
-Ensure the `GOOGLE_API_KEY` environment variable is set.
+This app uses Google's Gemini API for scanned PDFs/images when a key is
+provided.  Without a key it falls back to the local Tesseract engine.  Ensure
+either the `GOOGLE_API_KEY` environment variable is set or `tesseract` is
+installed on the host.

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import datetime
 import hashlib
-from src.gemini_ocr import ocr_image_bytes
+from src.ocr import ocr_image_bytes
 
 # Configure the page
 st.set_page_config(
@@ -126,7 +126,7 @@ OCR_SCALE = 2.0
 
 
 def _ocr_page(image_bytes: bytes) -> str:
-    """Run OCR on a PNG byte stream via Gemini."""
+    """Run OCR on a PNG byte stream via the configured backend."""
     try:
         return ocr_image_bytes(image_bytes)
     except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "python-multipart>=0.0.20",
     "streamlit>=1.47.0",
     "uvicorn[standard]>=0.35.0",
+    "pytesseract>=0.3.10",
 ]

--- a/replit.md
+++ b/replit.md
@@ -84,7 +84,7 @@ Preferred communication style: Simple, everyday language.
    - PDF is opened using PyMuPDF
    - Each page is processed sequentially
    - Direct text extraction is attempted first
-   - If no text is found, page is converted to image for OCR via Google Gemini
+   - If no text is found, page is converted to image for OCR via Google Gemini or local Tesseract
 3. **Text Aggregation**: Extracted text from all pages is combined
 4. **AI Processing**: Combined text can be sent to Groq API for analysis
 5. **Results Display**: Processed results are displayed in the Streamlit interface
@@ -94,12 +94,12 @@ Preferred communication style: Simple, everyday language.
 ## Core Libraries
 - **streamlit**: Web application framework
 - **PyMuPDF (fitz)**: PDF processing and manipulation
-- **requests**: HTTP client for Google Gemini API
+- **requests**: HTTP client for Google Gemini API (optional)
 - **PIL (Pillow)**: Image processing for OCR pipeline
 - **openai**: API client for AI model interaction
 
 ## System Dependencies
-- **Google Gemini API**: Used for OCR of scanned documents
+- **Google Gemini API** (optional) or **Tesseract**: OCR engines for scanned documents
 
 ## API Dependencies
 - **Groq API**: External AI service for text analysis
@@ -109,12 +109,12 @@ Preferred communication style: Simple, everyday language.
 
 ## Environment Requirements
 - Python runtime with required packages
-- Google Gemini API key
+- Optional Google Gemini API key or installed Tesseract binary
 - Network access to Groq API endpoints
 
 ## Configuration
 - **API Key**: Set via OPENAI_API_KEY environment variable
-- **OCR Languages**: Automatically handled by Gemini
+- **OCR Languages**: Automatically handled by Gemini/Tesseract
 - **Streamlit Config**: Centered layout, Hebrew interface
 
 ## Security Considerations

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-multipart>=0.0.20
 requests>=2.31.0
 streamlit>=1.47.0
 uvicorn[standard]>=0.35.0
+pytesseract>=0.3.10

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,0 +1,45 @@
+"""Unified OCR interface.
+
+The project historically relied on Google's Gemini API for optical character
+recognition.  This module wraps the Gemini implementation and provides a
+transparent fallback to the local Tesseract engine when a ``GOOGLE_API_KEY`` is
+not configured or the remote call fails.  The goal is to keep the rest of the
+codebase agnostic to the OCR backend while maximising reliability.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+from gemini_ocr import ocr_image_bytes as _gemini_ocr
+
+try:  # pragma: no cover - exercised in tests if available
+    from tesseract_ocr import ocr_image_bytes as _tesseract_ocr
+except Exception:  # pragma: no cover - defensive: pytesseract missing
+    _tesseract_ocr = None  # type: ignore
+
+
+def _tesseract_available() -> bool:
+    return _tesseract_ocr is not None and shutil.which("tesseract") is not None
+
+
+def ocr_image_bytes(image_bytes: bytes) -> str:
+    """Return text extracted from *image_bytes* using the best available OCR.
+
+    Preference is given to the Gemini API when a ``GOOGLE_API_KEY`` environment
+    variable is configured.  If Gemini fails or is unavailable, the function
+    falls back to a local Tesseract OCR implementation (if installed).
+    """
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if api_key:
+        try:
+            return _gemini_ocr(image_bytes)
+        except Exception:
+            pass
+
+    if _tesseract_available():
+        return _tesseract_ocr(image_bytes)  # type: ignore[misc]
+
+    raise RuntimeError("No OCR backend available")

--- a/src/tesseract_ocr.py
+++ b/src/tesseract_ocr.py
@@ -1,0 +1,44 @@
+"""Local OCR using Tesseract.
+
+This module provides a drop-in replacement for Gemini OCR using the
+`pytesseract` package.  It performs basic rotation handling similar to the
+Gemini implementation: the image is rotated in 90-degree increments and the
+longest result is returned.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Iterable
+
+from PIL import Image
+
+try:  # pragma: no cover - exercised in tests if available
+    import pytesseract
+except Exception:  # pragma: no cover - defensive: pytesseract not installed
+    pytesseract = None  # type: ignore
+
+
+_ROTATIONS: Iterable[int] = (0, 90, 180, 270)
+
+
+def ocr_image_bytes(image_bytes: bytes) -> str:
+    """Return text extracted from *image_bytes* using Tesseract.
+
+    The function attempts several rotations and returns the longest string.
+    A :class:`RuntimeError` is raised if ``pytesseract`` or the ``tesseract``
+    binary is not available.
+    """
+    if pytesseract is None or not pytesseract.get_tesseract_version():
+        raise RuntimeError("Tesseract is not installed")
+
+    image = Image.open(io.BytesIO(image_bytes))
+    best = ""
+    for angle in _ROTATIONS:
+        rotated = image.rotate(angle, expand=True)
+        text = pytesseract.image_to_string(rotated)
+        if len(text) > len(best):
+            best = text
+        if len(best.strip()) > 20:
+            break
+    return best.strip()

--- a/tests/test_tesseract_fallback.py
+++ b/tests/test_tesseract_fallback.py
@@ -1,0 +1,24 @@
+import io
+import os
+import shutil
+import sys
+
+import pytest
+from PIL import Image, ImageDraw
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+import ocr
+
+pytesseract = pytest.importorskip("pytesseract")
+if shutil.which("tesseract") is None:  # pragma: no cover - skip when not installed
+    pytest.skip("tesseract binary not installed", allow_module_level=True)
+
+
+def test_tesseract_basic():
+    img = Image.new("RGB", (100, 40), color="white")
+    draw = ImageDraw.Draw(img)
+    draw.text((10, 10), "Hello", fill="black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    text = ocr.ocr_image_bytes(buf.getvalue())
+    assert "Hello" in text


### PR DESCRIPTION
## Summary
- add local Tesseract OCR module and unified interface that falls back when Gemini fails or isn't configured
- switch application modules to use new OCR interface and update docs
- document optional Gemini key and add tests for Tesseract backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3066e17cc8330b1fc4abeca77b609